### PR TITLE
Fixed Exception while opening 1.17 snapshot Profile

### DIFF
--- a/src/parsers/parseCrash.js
+++ b/src/parsers/parseCrash.js
@@ -68,7 +68,7 @@ function parseCrash(data)
                     retData.details.players = [];
                     
                     // Using sketchy regex on a data source I don't own (or even understand)? What could go wrong?
-                    let players = parts[1].match(/(?:\[([^\[\]]+?)\])+/);
+                    let players = parts[1].match(/(?:\[(.*?)\](?:,|\]))+/);
                     players.splice(0, 1);
                     for(let player of players)
                     {


### PR DESCRIPTION
```
TypeError: Cannot read property '1' of null
    at S (parseCrash.js:76)
    at parseZip.js:38
    at l (runtime.js:45)
    at Generator._invoke (runtime.js:274)
    at Generator.O.forEach.t.<computed> [as next] (runtime.js:97)
    at o (asyncToGenerator.js:5)
    at s (asyncToGenerator.js:27)
```